### PR TITLE
feat: add alternate extra wall feature

### DIFF
--- a/resources/profiles/3DLabs/process/fdm_process_common.json
+++ b/resources/profiles/3DLabs/process/fdm_process_common.json
@@ -39,6 +39,7 @@
     "reduce_infill_retraction": "0",
     "filename_format": "{input_filename_base}.gcode",
     "wall_loops": "3",
+    "alternate_extra_wall": "0",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "40",
     "print_settings_id": "",

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1484,6 +1484,9 @@ void PerimeterGenerator::process_classic()
     for (const Surface &surface : all_surfaces) {
         // detect how many perimeters must be generated for this island
         int        loop_number = this->config->wall_loops + surface.extra_perimeters - 1;  // 0-indexed loops
+        int sparse_infill_density = this->config->sparse_infill_density.value;
+        if (this->config->alternate_extra_wall && this->layer_id % 2 == 1 && !m_spiral_vase && sparse_infill_density > 0) // add alternating extra wall
+            loop_number++;
         if (this->layer_id == 0 && this->config->only_one_wall_first_layer)
             loop_number = 0;
         //BBS: set the topmost layer to be one wall
@@ -2011,6 +2014,9 @@ void PerimeterGenerator::process_arachne()
             bead_width_0 = ext_perimeter_width + this->perimeter_flow.scaled_width() - perimeter_spacing;
         // detect how many perimeters must be generated for this island
         int        loop_number = this->config->wall_loops + surface.extra_perimeters - 1; // 0-indexed loops
+        int sparse_infill_density = this->config->sparse_infill_density.value;
+        if (this->config->alternate_extra_wall && this->layer_id % 2 == 1 && !m_spiral_vase && sparse_infill_density > 0) // add alternating extra wall
+            loop_number++;
         if (this->layer_id == 0 && this->config->only_one_wall_first_layer)
             loop_number = 0;
         // BBS: set the topmost layer to be one wall

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2776,6 +2776,14 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->max = 1000;
     def->set_default_value(new ConfigOptionInt(2));
+
+    def = this->add("alternate_extra_wall", coBool);
+    def->label = L("Alternate extra wall");
+    def->category = L("Strength");
+    def->tooltip = L("This setting adds an extra wall to every other layer. This way the infill gets wedged vertically between the walls, resulting in stronger prints.\n\n"
+                     "When this option is enabled, the ensure vertical shell thickness option needs to be disabled.\n\n"
+                     "Using lightning infill together with this option is not recommended as there is limited infill to anchor the extra perimeters to.");
+    def->set_default_value(new ConfigOptionBool(false));
     
     def = this->add("post_process", coStrings);
     def->label = L("Post-processing Scripts");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -795,6 +795,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat, inner_wall_speed))
     // Total number of perimeters.
     ((ConfigOptionInt, wall_loops))
+    ((ConfigOptionBool, alternate_extra_wall))
     ((ConfigOptionFloat, minimum_sparse_infill_area))
     ((ConfigOptionInt, solid_infill_filament))
     ((ConfigOptionFloatOrPercent, internal_solid_infill_line_width))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -902,6 +902,7 @@ bool PrintObject::invalidate_state_by_config_options(
             }
         } else if (
                opt_key == "wall_loops"
+            || opt_key == "alternate_extra_wall"
             || opt_key == "only_one_wall_top"
             || opt_key == "only_one_wall_first_layer"
             || opt_key == "extra_perimeters_on_overhangs"

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1922,6 +1922,7 @@ void TabPrint::build()
     page = add_options_page(L("Strength"), "empty");
         optgroup = page->new_optgroup(L("Walls"), L"param_wall");
         optgroup->append_single_option_line("wall_loops");
+        optgroup->append_single_option_line("alternate_extra_wall");
         optgroup->append_single_option_line("detect_thin_wall");
 
         optgroup = page->new_optgroup(L("Top/bottom shells"), L"param_shell");


### PR DESCRIPTION
Adds an extra perimeter wall on alternating layers to improve print strength by creating mechanical interlocking between layers. The infill gets "wedged" vertically between walls, resulting in stronger prints.

- Added alternate_extra_wall boolean config option
- GUI control in Strength tab > Walls section
- Implemented in both Classic and Arachne perimeter generators
- Only activates on odd layers when infill > 0 and not in spiral vase mode
- Updated common profile with default value